### PR TITLE
modified: add .DS_Store and Thumbs.db to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.DS_Store
+Thumbs.db
 .idea/


### PR DESCRIPTION
## 概要と目的
.gitignore に DS_Store と Thumbs.db を追加

## やったこと
同上

## レビュアーに見て欲しいところ

## 対応するIssue
なし

### その他
なし