### PR TITLE
共同代表以外のメンバープロフィールを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,197 +365,23 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/ryo1.png" class="img-responsive img-circle" alt="">
-            <h4>Ryo Murakami</h4>
-            <p class="text-muted">Founder/Leader</p>
-            <ul class="list-inline social-buttons">
-              <li><a href="https://twitter.com/Brains_Info_TKB" target="_blank"><i class="fa fa-twitter"></i></a>
-              </li>
-              <li><a href="https://www.facebook.com/ryo.murakami.3998" target="_blank"><i class="fa fa-facebook"></i></a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/gassan.jpg" class="img-responsive img-circle" alt="">
-            <h4>衣笠 尚暉</h4>
-            <p class="text-muted">生物学類 4年</p>
-            <ul class="list-inline social-buttons">
-              <li><a href="https://twitter.com/nktng117"><i class="fa fa-twitter"></i></a>
-              </li>
-              <li><a href="https://www.facebook.com/afterschool117"><i class="fa fa-facebook"></i></a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/yohei.jpg" class="img-responsive img-circle" alt="">
-            <h4>長谷川 陽平</h4>
-            <p class="text-muted">CTO / 情報メディア創成学類 4年</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-	      <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/kuro_photo.jpg" class="img-responsive img-circle" alt="">
-            <h4>黒澤　翔</h4>
-            <p class="text-muted">応用理工学類 OB</p>
-	          <ul class="list-inline social-buttons">
-              <li><a href="https://www.facebook.com/kakeru.kurosawa.35"><i class="fa fa-facebook"></i></a></li>
-	            <li><a href="https://www.instagram.com/?hl=ja"><i class="fa fa-instagram"></i></a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/kodai.jpg" class="img-responsive img-circle" alt="">
-            <h4>瀧川 滉大</h4>
-            <p class="text-muted">工学システム学類 3年</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/akasaka.jpg" class="img-responsive img-circle" alt="">
-            <h4>赤坂 勝哉</h4>
-            <p class="text-muted">情報科学類 4年</p>
-            <ul class="list-inline social-buttons">
-              <li><a href="https://www.facebook.com/profile.php?id=100015519998667"><i class="fa fa-facebook"></i></a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/FumiyaYoshida.jpg" class="img-responsive img-circle" alt="">
-            <h4>吉田　史弥</h4>
-            <p class="text-muted">物理学類 4年</p>
-            <ul class="list-inline social-buttons">
-              <li><a href="https://www.facebook.com/fu.yo.526"><i class="fa fa-facebook"></i></a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/waseda.jpg" class="img-responsive img-circle" alt="">
-            <h4>早稲田　英司</h4>
-            <p class="text-muted">体育専門学群 4年</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
+        <div class="col-sm-6">
           <div class="team-member">
             <img src="img/team/niwa.jpg" class="img-responsive img-circle" alt="">
             <h4>仁和　活貴</h4>
-            <p class="text-muted">工学システム学類 2年</p>
+            <p class="text-muted">Brains 共同代表</p>
+            <p class="text-muted">工学システム学類 3年</p>
             <ul class="list-inline social-buttons">
               <li><a href="https://www.facebook.com/profile.php?id=100008498430388"><i class="fa fa-facebook"></i></a></li>
             </ul>
           </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/habatasu.png" class="img-responsive img-circle" alt="">
-            <h4>幅田　悠斗</h4>
-            <p class="text-muted">応用理工学類 4年</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/photo-fb-ts.jpg" class="img-responsive img-circle" alt="">
-            <h4>Seiya Tajima</h4>
-            <p class="text-muted">Supporter/Adviser</p>
-            <ul class="list-inline social-buttons">
-              <li><a href="https://twitter.com/seinto326" target="_blank"><i class="fa fa-twitter"></i></a></li>
-              <li><a href="https://www.facebook.com/tajima.seiya" target="_blank"><i class="fa fa-facebook"></i></a></li>
-              <li><a href="https://www.linkedin.com/in/seiya-tajima-84b07098/" target="_blank"><i class="fa fa-linkedin"></i></a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/koyamaso.jpg" class="img-responsive img-circle" alt="">
-            <h4>小山　創平</h4>
-            <p class="text-muted">情報科学類 1年</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/narita.png" class="img-responsive img-circle" alt="成田和彦の画像">
-            <h4>成田　和彦</h4>
-            <p class="text-muted">工学システム学類 OB</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/nakai.jpg" class="img-responsive img-circle" alt="">
-            <h4>中井　優</h4>
-            <p class="text-muted">数学類 1年</p>
-            <ul class="list-inline social-buttons">
-              <li><a href="https://twitter.com/TOnakai_nakai" target="_blank"><i class="fa fa-twitter"></i></a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/shibatakoki.jpg" class="img-responsible img-circle" alt="">
-            <h4>Koki Shibata</h4>
-            <p class="text-muted">知識情報・図書館学類 1年</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/yoshinaga.jpg" class="img-responsive img-circle" alt="">
-            <h4>吉永　享太</h4>
-            <p class="text-muted">応用理工学類 1年</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/egashira.jpg" class="img-responsive img-circle" alt="">
-            <h4>江頭　輝</h4>
-            <p class="text-muted">情報科学類 1年</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/kai.jpg" class="img-responsive img-circle" alt="">
-            <h4>高橋　快</h4>
-            <p class="text-muted">情報科学類 1年</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/Jitsukawa_Tomoki.jpg" class="img-responsive img-circle" alt="">
-            <h4>實川　智貴</h4>
-            <p class="text-muted">情報メディア創成学類 1年</p>
-          </div>
-        </div>
-        <div class="col-sm-4">
-          <div class="team-member">
-            <img src="img/team/nagao.jpg" class="img-responsive img-circle" alt="">
-            <h4>長尾 恭太</h4>
-            <p class="text-muted">情報科学類 4年</p>
-          </div>
-        </div>
-	<div class="col-sm-4">
+        <div class="col-sm-6">
           <div class="team-member">
             <img src="img/team/_20180704_174433.jpg" class="img-responsive img-circle" alt="">
             <h4>半澤 輝尚</h4>
-            <p class="text-muted">情報メディア創成学類 2年</p>
+            <p class="text-muted">Brains 共同代表</p>
+            <p class="text-muted">情報メディア創成学類 3年</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要と目的
メンバーセクションに各メンバーのプロフィールを載せるのをやめることになったため, 該当箇所を削除.

## やったこと
現共同代表(2019/03/31) メンバー以外のプロフィールを削除.

## レビュアーに見て欲しいところ
なし.

## 対応するIssue
なし.

### その他
活動メンバーの所属学類などの情報を別のPRで対応してください.
